### PR TITLE
Adding functions to set and clear a bit in a byte

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,17 +1,21 @@
 
 ### High Priority
 
-- [x] Write unit tests for reading the super block.
-- [ ] Write unit tests for reading the group descriptor.
-- [x] Write a test build in the Makefile.
-- [ ] Write failing tests for reading the imap and the bmap.
-- [ ] Write failing tests for hex to binary conversion and vice versa.
-    - [ ] Work on imap.
-        - [ ] decoding hex to binary with the correct bit order.
-        - [ ] building a bit map for inodes.
+- [ ] Write tests for setting a bit in a byte.
+- [ ] Write tests for clearing a bit in a byte.
 
 ### Lower Priority
 
-- [ ] Write a note on design choice for data types (i8, u8, i32, u32,...) for efficient byte array decoding/encoding
-- [ ] Write a note on design choice using both `i8 *` and `std::string`
+- [ ] Implement `FS::Read` and `FS::Show` for the root node.
+- [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
+
+## Done
+
+- [x] Write unit tests for reading the super block.
+- [x] Write a test build in the Makefile.
+- [x] Work on imap.
+    - [x] decoding hex to binary with the correct bit order.
+    - [x] building a bit map for inodes.
+- [x] Write a note on design choice for data types (i8, u8, i32, u32,...) for efficient byte array decoding/encoding
+- [x] Write a note on design choice using both `i8 *` and `std::string`
 

--- a/app-c/Makefile
+++ b/app-c/Makefile
@@ -27,7 +27,7 @@ src_test_units  := src/test-units
 build_units     := ${target_test}/units
 build_runner    := ${target_test}
 
-test_units_o    := fs.ext2.o fs.ext2.imap.o
+test_units_o    := fs.ext2.o fs.ext2.imap.o fs.ext2.imap.bits.o
 
 test_units_o    := ${addprefix ${build_units}/, ${test_units_o}}
 

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -114,14 +114,22 @@ namespace FS {
         struct EXT2 {
 
             /**
-             * helper function that check and set the bits in a byte.
+             * build a bitmap from the byte passed in.
              */
-            static u8 *hex2bitstring(u8 value) {
+            static u8 *byte2bitstring(u8 value) {
                 u8 *bitstring = (u8 *)malloc(sizeof(u8) * 8);
                 for (u8 i = 0; i < 8; ++i) {
                     bitstring[i] = (value & static_cast<u8>(1 << (i % 8))) >> (i % 8);
                 }
                 return bitstring;
+            }
+
+            static u8 set_bit(u8 byte, u32 position) {
+                return byte || (1 << position);
+            }
+
+            static u8 clear_bit(u8 byte, u32 position) {
+                return byte & ~(1 << position);
             }
 
             /**
@@ -146,7 +154,7 @@ namespace FS {
                 printf("\nimap: as 8-bit stringss\n");
                 for (u32 i = 0; i <= num_inodes / 8; ++i) {
                     printf("\tbytes[%02d]  %02x  ", i + 1, (u8)imap[i]);
-                    u8 *bitstring = hex2bitstring((u8)imap[i]);
+                    u8 *bitstring = byte2bitstring((u8)imap[i]);
                     print_bitstring(bitstring);
                     delete bitstring;
                 }

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -124,12 +124,12 @@ namespace FS {
                 return bitstring;
             }
 
-            static u8 set_bit(u8 byte, u32 position) {
-                return byte || (1 << position);
+            static u8 set_bit(u8 byte, u8 index) {
+                return byte | (u8)(1 << index);
             }
 
-            static u8 clear_bit(u8 byte, u32 position) {
-                return byte & ~(1 << position);
+            static u8 clear_bit(u8 byte, u8 index) {
+                return byte & (u8) ~(1 << index);
             }
 
             /**

--- a/app-c/src/test-units/all-tests.hpp
+++ b/app-c/src/test-units/all-tests.hpp
@@ -23,5 +23,6 @@ struct Test {
 
 void test_fs_ext2();
 void test_fs_ext2_imap();
+void test_fs_ext2_imap_bits();
 
 #endif

--- a/app-c/src/test-units/fs.ext2.imap.bits.cc
+++ b/app-c/src/test-units/fs.ext2.imap.bits.cc
@@ -1,0 +1,66 @@
+#include "../hdr-locked/constants.hpp"
+#include "../hdr-locked/my-fs.hpp"
+#include "../hdr-locked/my-types.hpp"
+
+#include "all-tests.hpp"
+
+#include <cassert>
+
+using std::string;
+
+/**
+ * Integration test. create a new disk and read from it.
+ */
+bool _test_fs_ext2_imap_bits() {
+    /**
+     * SET UP
+     */
+    /**
+     * TEST BODY
+     */
+    {
+        /**
+         * test setting a bit in a byte.
+         *
+         *                    76543210
+         * value  =  80d -> 0x01010000
+         * bit_index     ->     5
+         * result = 112d -> 0x01110000
+         */
+        u8 value     = 80;
+        u8 bit_index = 5;
+        u8 expect    = 112;
+
+        u32 result = FS::Show::EXT2::set_bit(value, bit_index);
+        assert(result == expect);
+
+        /**
+         * test clearing a bit from a byte.
+         *
+         *                    76543210
+         * value  = 112d -> 0x01110000
+         * bit_index     ->     5
+         * result =  80d -> 0x01010000
+         */
+        value     = 112;
+        bit_index = 5;
+        expect    = 80;
+
+        result = FS::Show::EXT2::clear_bit(value, bit_index);
+        assert(result == expect);
+    }
+
+    /**
+     * TEAR DOWN
+     */
+    return true;
+}
+
+/**
+ * test executor.
+ */
+void test_fs_ext2_imap_bits() {
+    Test::Header("sets and clears a bit in a byte (8-bit map)");
+    bool result = Test::Body(*_test_fs_ext2_imap_bits);
+    Test::Footer(result);
+}

--- a/app-c/src/test-units/fs.ext2.imap.cc
+++ b/app-c/src/test-units/fs.ext2.imap.cc
@@ -26,7 +26,6 @@ bool _test_fs_ext2_imap() {
         system(create_test_disk.c_str());
     }();
 
-
     /**
      * TEST BODY
      */
@@ -37,8 +36,38 @@ bool _test_fs_ext2_imap() {
         FS::Read::EXT2::super(&vdisk);
         FS::Read::EXT2::group_desc(&vdisk);
         FS::Read::EXT2::imap(&vdisk);
-
+        // show bitmap of inodes.
         FS::Show::EXT2::imap(&vdisk);
+
+        /**
+         * test setting a bit in a byte.
+         *
+         *                    76543210
+         * value  =  80d -> 0x01010000
+         * bit_index     ->     5
+         * result = 112d -> 0x01110000
+         */
+        u32 value     = 80;
+        u32 bit_index = 5;
+        u32 expect    = 112;
+
+        u32 result = FS::Show::EXT2::set_bit(value, bit_index);
+        assert(result == expect);
+
+        /**
+         * test clearing a bit from a byte.
+         *
+         *                    76543210
+         * value  = 112d -> 0x01110000
+         * bit_index     ->     5
+         * result =  80d -> 0x01010000
+         */
+        value     = 112;
+        bit_index = 5;
+        expect    = 80;
+
+        result = FS::Show::EXT2::clear_bit(value, bit_index);
+        assert(result == expect);
     }
 
     /**

--- a/app-c/src/test-units/fs.ext2.imap.cc
+++ b/app-c/src/test-units/fs.ext2.imap.cc
@@ -38,36 +38,6 @@ bool _test_fs_ext2_imap() {
         FS::Read::EXT2::imap(&vdisk);
         // show bitmap of inodes.
         FS::Show::EXT2::imap(&vdisk);
-
-        /**
-         * test setting a bit in a byte.
-         *
-         *                    76543210
-         * value  =  80d -> 0x01010000
-         * bit_index     ->     5
-         * result = 112d -> 0x01110000
-         */
-        u32 value     = 80;
-        u32 bit_index = 5;
-        u32 expect    = 112;
-
-        u32 result = FS::Show::EXT2::set_bit(value, bit_index);
-        assert(result == expect);
-
-        /**
-         * test clearing a bit from a byte.
-         *
-         *                    76543210
-         * value  = 112d -> 0x01110000
-         * bit_index     ->     5
-         * result =  80d -> 0x01010000
-         */
-        value     = 112;
-        bit_index = 5;
-        expect    = 80;
-
-        result = FS::Show::EXT2::clear_bit(value, bit_index);
-        assert(result == expect);
     }
 
     /**

--- a/app-c/src/test/runner.cc
+++ b/app-c/src/test/runner.cc
@@ -8,6 +8,7 @@ int main() {
     printf("\n\nRUNNING TESTS.\n\n");
     //test_fs_ext2();
     test_fs_ext2_imap();
+    test_fs_ext2_imap_bits();
 
     printf("\n\nALL: PASSED.\n");
 }


### PR DESCRIPTION
- Added implementation for setting and clearing a positional bit in a byte.
- Updated TODO.
- Added tests for setting and clearing a bit in a byte value.
- Finished implemening FS::Show::EXT2 set_bit and clear bit.
