### PR TITLE
Small change: from (NOT AND) to (XOR)

### DIFF
--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -129,7 +129,7 @@ namespace FS {
             }
 
             static u8 clear_bit(u8 byte, u8 index) {
-                return byte & (u8) ~(1 << index);
+                return byte ^ (u8)(1 << index);
             }
 
             /**


### PR DESCRIPTION
- Changed `& ~` (AND NOT) to `^` (XOR) in clear_bit().
