### PR TITLE
Showing the dir entries of the root node/dir

### DIFF
--- a/.archive/hdr/type.h
+++ b/.archive/hdr/type.h
@@ -15,8 +15,8 @@
 #if defined(_WIN32)
 #include "ext2fs/ext2_fs.h"
 #elif __linux__
-#include "ext2fs/ext2_fs.h"
-//#include <ext2fs/ext2_fs.h>
+//#include "ext2fs/ext2_fs.h"
+#include <ext2fs/ext2_fs.h>
 #endif
 
 // define shorter TYPES, save typing efforts

--- a/.archive/src/cd_ls_pwd.c
+++ b/.archive/src/cd_ls_pwd.c
@@ -133,6 +133,13 @@ int ls_dir(MINODE *pip) {
     dp = (DIR *)sbuf;
     cp = sbuf;
 
+    for (int i = 0; i < 15; i++) {
+        // print disk block numbers
+        /*if (ip->i_block[i])*/
+            // print non-zero blocks only
+        printf("i_block[%d] = %d\n", i, ip->i_block[i]);
+    }
+
     if (strcmp(dp->name, "/") == 0) {
         name[dp->name_len] = 0;
         print_i_mode(ip);
@@ -200,7 +207,7 @@ int rpwd(MINODE *wd) {
     int blk    = (pino - 1) / 8 + inodes_start;
     int offset = (pino - 1) % 8;
     get_block(dev, blk, buf);
-    DIR *dp = (DIR *)buf + offset;
+    DIR *dp                   = (DIR *)buf + offset;
     char name_buf[BLOCK_SIZE] = {0};
     strncpy(name_buf, dp->name, dp->name_len);
     printf("%s", name_buf);

--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -25,7 +25,7 @@
             "state": {
               "type": "markdown",
               "state": {
-                "file": "TODO.md",
+                "file": "model/system-test/strategy.md",
                 "mode": "source",
                 "source": false
               }
@@ -98,7 +98,7 @@
             "state": {
               "type": "backlink",
               "state": {
-                "file": "TODO.md",
+                "file": "model/system-test/strategy.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -115,7 +115,7 @@
             "state": {
               "type": "outgoing-link",
               "state": {
-                "file": "TODO.md",
+                "file": "model/system-test/strategy.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               }
@@ -150,7 +150,7 @@
             "state": {
               "type": "outline",
               "state": {
-                "file": "TODO.md"
+                "file": "model/system-test/strategy.md"
               }
             }
           },
@@ -182,8 +182,8 @@
   },
   "active": "3cc7e54361c2d364",
   "lastOpenFiles": [
-    "TODO_DONE.md",
     "TODO.md",
+    "TODO_DONE.md",
     "model/system-test/strategy.md",
     "model/design.md",
     "model/system-build/using-Makefile.md",

--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -4,35 +4,18 @@
     "type": "split",
     "children": [
       {
-        "id": "ea0ccd7984a2ce50",
+        "id": "b7f7fafbe55aeb7c",
         "type": "tabs",
         "children": [
           {
-            "id": "d0186056d74472f4",
+            "id": "e8878690dd710d7b",
             "type": "leaf",
             "state": {
-              "type": "markdown",
-              "state": {
-                "file": "TODO.md",
-                "mode": "source",
-                "source": false
-              }
-            }
-          },
-          {
-            "id": "3cc7e54361c2d364",
-            "type": "leaf",
-            "state": {
-              "type": "markdown",
-              "state": {
-                "file": "model/system-test/strategy.md",
-                "mode": "source",
-                "source": false
-              }
+              "type": "empty",
+              "state": {}
             }
           }
-        ],
-        "currentTab": 1
+        ]
       }
     ],
     "direction": "vertical"
@@ -82,7 +65,8 @@
       }
     ],
     "direction": "horizontal",
-    "width": 300
+    "width": 300,
+    "collapsed": true
   },
   "right": {
     "id": "dd8c4d0a71594dd6",
@@ -98,7 +82,6 @@
             "state": {
               "type": "backlink",
               "state": {
-                "file": "model/system-test/strategy.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -115,7 +98,6 @@
             "state": {
               "type": "outgoing-link",
               "state": {
-                "file": "model/system-test/strategy.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               }
@@ -149,9 +131,7 @@
             "type": "leaf",
             "state": {
               "type": "outline",
-              "state": {
-                "file": "model/system-test/strategy.md"
-              }
+              "state": {}
             }
           },
           {
@@ -180,11 +160,11 @@
       "table-editor-obsidian:Advanced Tables Toolbar": false
     }
   },
-  "active": "3cc7e54361c2d364",
+  "active": "e8878690dd710d7b",
   "lastOpenFiles": [
     "TODO.md",
-    "TODO_DONE.md",
     "model/system-test/strategy.md",
+    "TODO_DONE.md",
     "model/design.md",
     "model/system-build/using-Makefile.md",
     "app-c/build/bin/app",

--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -13,7 +13,7 @@
             "state": {
               "type": "markdown",
               "state": {
-                "file": "model/system-test/strategy.md",
+                "file": "TODO.md",
                 "mode": "source",
                 "source": false
               }
@@ -85,7 +85,7 @@
             "state": {
               "type": "backlink",
               "state": {
-                "file": "model/system-test/strategy.md",
+                "file": "TODO.md",
                 "collapseAll": false,
                 "extraContext": false,
                 "sortOrder": "alphabetical",
@@ -102,7 +102,7 @@
             "state": {
               "type": "outgoing-link",
               "state": {
-                "file": "model/system-test/strategy.md",
+                "file": "TODO.md",
                 "linksCollapsed": false,
                 "unlinkedCollapsed": true
               }
@@ -125,7 +125,9 @@
             "state": {
               "type": "all-properties",
               "state": {
-                "sortOrder": "frequency"
+                "sortOrder": "frequency",
+                "showSearch": false,
+                "searchQuery": ""
               }
             }
           },
@@ -135,7 +137,7 @@
             "state": {
               "type": "outline",
               "state": {
-                "file": "model/system-test/strategy.md"
+                "file": "TODO.md"
               }
             }
           },
@@ -167,8 +169,8 @@
   },
   "active": "d0186056d74472f4",
   "lastOpenFiles": [
-    "model/design.md",
     "model/system-test/strategy.md",
+    "model/design.md",
     "model/system-build/using-Makefile.md",
     "app-c/build/bin/app",
     "app-c/build/obj/sub.o",

--- a/.obsidian/workspace.json
+++ b/.obsidian/workspace.json
@@ -18,8 +18,21 @@
                 "source": false
               }
             }
+          },
+          {
+            "id": "3cc7e54361c2d364",
+            "type": "leaf",
+            "state": {
+              "type": "markdown",
+              "state": {
+                "file": "TODO.md",
+                "mode": "source",
+                "source": false
+              }
+            }
           }
-        ]
+        ],
+        "currentTab": 1
       }
     ],
     "direction": "vertical"
@@ -167,8 +180,10 @@
       "table-editor-obsidian:Advanced Tables Toolbar": false
     }
   },
-  "active": "d0186056d74472f4",
+  "active": "3cc7e54361c2d364",
   "lastOpenFiles": [
+    "TODO_DONE.md",
+    "TODO.md",
     "model/system-test/strategy.md",
     "model/design.md",
     "model/system-build/using-Makefile.md",

--- a/TODO.md
+++ b/TODO.md
@@ -10,6 +10,7 @@
 - [ ] Plan out the *first set of function* that interfaces with `FS::EXT2`.
     - mkdir
     - creat
+- [ ] review the data type model.
 
 ## Done
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,15 +1,11 @@
 
 ### High Priority
 
-- [x] Review KC's book p.230 Mount Partitions.
-    - [x] create and mount an ext2 vdisk.
-
-- [ ] Implement `FS::Read` and `FS::Show` for the root node.
-    - BUG: `iblock[0]` doesn't show anything.
-    - FIX:
-        - ensure I have the chain of `Read` mapped out in correct order.
-        - review the `GD` and `INODE` structs.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
+    - [x] Implement test.
+    - BUG: The while loop in `FS::Show::EXT2::root_node` doesn't terminate.
+    - FIX:
+        - [ ] identify the break condition(s).
 
 ### Lower Priority
 
@@ -19,3 +15,15 @@
     - mkdir
     - creat
 - [ ] review the data type model.
+
+## Done
+
+- [x] Review KC's book p.230 Mount Partitions.
+    - [x] create and mount an ext2 vdisk.
+
+- [x] Implement `FS::Read` and `FS::Show` for the root node.
+    - BUG: `iblock[0]` doesn't show anything.
+    - FIX:
+        - [x] ensure I have the chain of `Read` mapped out in correct order.
+        - [x] review the `GD` and `INODE` structs.
+    - NOTE: `FS::Read::EXT2::inode_table` is correct. The disk created by the automaton script is faulty. Using the course's vdisk shows the disk block.

--- a/TODO.md
+++ b/TODO.md
@@ -1,18 +1,16 @@
 
 ### High Priority
 
-- [x] Implement `FS::Read` and `FS::Show` for the root node.
-    - NOTE:
-        - at the moment there is <u>no</u> root node *on any newly created disk*.
-        - will use KC's vdisk sample from now on for dev and testing.
-        - ~~will need to set a record for the root node via `DIR_ENTRY`.~~
-        
-- [x] Implement the namespace `FS::Write`.
+- [x] Review KC's book p.230 Mount Partitions.
+    - [x] create and mount an ext2 vdisk.
+
+- [ ] Implement `FS::Read` and `FS::Show` for the root node.
+    - BUG: `iblock[0]` doesn't show anything.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
-    - [ ] Implement `FS::Write` for `DIR_ENTRY`.
 
 ### Lower Priority
 
+- [ ] Implement `FS::Write` for `DIR_ENTRY`.
 - [ ] Peruse KC's book on the next components of the FS.
 - [ ] Plan out the *first set of function* that interfaces with `FS::EXT2`.
     - mkdir

--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,11 @@
 ### High Priority
 
 - [x] Implement `FS::Read` and `FS::Show` for the root node.
+    - NOTE:
+        - at the moment the root node is empty without a record.
+        - will need to set a record for the root node via `DIR_ENTRY`.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
+    - [ ] Implement `FS::Write` for `DIR_ENTRY`.
 
 ### Lower Priority
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,16 +1,20 @@
 
 ### High Priority
 
-- [ ] Write tests for setting a bit in a byte.
-- [ ] Write tests for clearing a bit in a byte.
-
-### Lower Priority
-
 - [ ] Implement `FS::Read` and `FS::Show` for the root node.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
 
+### Lower Priority
+
+- [ ] Peruse KC's book on the next components of the FS.
+- [ ] Plan out the *first set of function* that interfaces with `FS::EXT2`.
+    - mkdir
+    - creat
+
 ## Done
 
+- [x] Write tests for setting a bit in a byte.
+- [x] Write tests for clearing a bit in a byte.
 - [x] Write unit tests for reading the super block.
 - [x] Write a test build in the Makefile.
 - [x] Work on imap.

--- a/TODO.md
+++ b/TODO.md
@@ -6,6 +6,9 @@
 
 - [ ] Implement `FS::Read` and `FS::Show` for the root node.
     - BUG: `iblock[0]` doesn't show anything.
+    - FIX:
+        - ensure I have the chain of `Read` mapped out in correct order.
+        - review the `GD` and `INODE` structs.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
 
 ### Lower Priority

--- a/TODO.md
+++ b/TODO.md
@@ -1,7 +1,7 @@
 
 ### High Priority
 
-- [ ] Implement `FS::Read` and `FS::Show` for the root node.
+- [x] Implement `FS::Read` and `FS::Show` for the root node.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
 
 ### Lower Priority
@@ -11,16 +11,3 @@
     - mkdir
     - creat
 - [ ] review the data type model.
-
-## Done
-
-- [x] Write tests for setting a bit in a byte.
-- [x] Write tests for clearing a bit in a byte.
-- [x] Write unit tests for reading the super block.
-- [x] Write a test build in the Makefile.
-- [x] Work on imap.
-    - [x] decoding hex to binary with the correct bit order.
-    - [x] building a bit map for inodes.
-- [x] Write a note on design choice for data types (i8, u8, i32, u32,...) for efficient byte array decoding/encoding
-- [x] Write a note on design choice using both `i8 *` and `std::string`
-

--- a/TODO.md
+++ b/TODO.md
@@ -3,8 +3,10 @@
 
 - [x] Implement `FS::Read` and `FS::Show` for the root node.
     - NOTE:
-        - at the moment the root node is empty without a record.
-        - will need to set a record for the root node via `DIR_ENTRY`.
+        - at the moment there is <u>no</u> root node *on any newly created disk*.
+        - will use KC's vdisk sample from now on for dev and testing.
+        - ~~will need to set a record for the root node via `DIR_ENTRY`.~~
+        
 - [x] Implement the namespace `FS::Write`.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
     - [ ] Implement `FS::Write` for `DIR_ENTRY`.

--- a/TODO.md
+++ b/TODO.md
@@ -5,6 +5,7 @@
     - NOTE:
         - at the moment the root node is empty without a record.
         - will need to set a record for the root node via `DIR_ENTRY`.
+- [x] Implement the namespace `FS::Write`.
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
     - [ ] Implement `FS::Write` for `DIR_ENTRY`.
 

--- a/TODO.md
+++ b/TODO.md
@@ -1,13 +1,14 @@
 
-### High Priority
+## High Priority
 
 - [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
     - [x] Implement test.
     - BUG: The while loop in `FS::Show::EXT2::root_node` doesn't terminate.
     - FIX:
+        - [ ] show details of the first dir entry record. (using printf)
         - [ ] identify the break condition(s).
 
-### Lower Priority
+## Lower Priority
 
 - [ ] Implement `FS::Write` for `DIR_ENTRY`.
 - [ ] Peruse KC's book on the next components of the FS.
@@ -18,12 +19,3 @@
 
 ## Done
 
-- [x] Review KC's book p.230 Mount Partitions.
-    - [x] create and mount an ext2 vdisk.
-
-- [x] Implement `FS::Read` and `FS::Show` for the root node.
-    - BUG: `iblock[0]` doesn't show anything.
-    - FIX:
-        - [x] ensure I have the chain of `Read` mapped out in correct order.
-        - [x] review the `GD` and `INODE` structs.
-    - NOTE: `FS::Read::EXT2::inode_table` is correct. The disk created by the automaton script is faulty. Using the course's vdisk shows the disk block.

--- a/TODO.md
+++ b/TODO.md
@@ -1,12 +1,10 @@
 
 ## High Priority
 
-- [ ] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
-    - [x] Implement test.
-    - BUG: The while loop in `FS::Show::EXT2::root_node` doesn't terminate.
-    - FIX:
-        - [ ] show details of the first dir entry record. (using printf)
-        - [ ] identify the break condition(s).
+- [ ] Review the code Reading and Showing `inode_table` and `root_node`.
+- [ ] Find a way to write more deterministic tests for them.
+    - The tests could try to address the case where `ino` exceeds the total number of inodes on disk.
+    - The tests could try to address the case where `ino` for the `root_node` is 1.
 
 ## Lower Priority
 
@@ -18,4 +16,17 @@
 - [ ] review the data type model.
 
 ## Done
+
+- [x] Implement `FS::Read` and `FS::Show` for `DIR_ENTRY`.
+    - [x] Implement test.
+    - BUG: The while loop in `FS::Show::EXT2::root_node` doesn't terminate.
+    - FIX:
+        - [x] show details of the first dir entry record. (using printf)
+        - [x] identify the break condition(s).
+            - the break condition is when the *value* of the record pointer `i8 *rp` is equal to the start of inode table + `BASE_BLOCK_SIZE`.
+    - NOTE:
+        - the bug was located at `FS::Read::EXT2::root_node`, where we need to increment the `ip` by 1, because inode numbers are 1-based indices.
+        - GUESS (could be wrong, will check again later):
+            - a pointer is simply the address to the start of a contiguous chunk of memory.
+            - when it is cast to another type, the step of pointer arithmetic changes. For example, when we cast an `i8 *rp` to `INODE *ip`, the increment by `sizeof(i8)` will now increment by `sizeof(INODE)`.
 

--- a/TODO_DONE.md
+++ b/TODO_DONE.md
@@ -1,4 +1,13 @@
 
+- [x] Review KC's book p.230 Mount Partitions.
+    - [x] create and mount an ext2 vdisk.
+
+- [x] Implement `FS::Read` and `FS::Show` for the root node.
+    - BUG: `iblock[0]` doesn't show anything.
+    - FIX:
+        - [x] ensure I have the chain of `Read` mapped out in correct order.
+        - [x] review the `GD` and `INODE` structs.
+    - NOTE: `FS::Read::EXT2::inode_table` is correct. The disk created by the automaton script is faulty. Using the course's vdisk shows the disk block.
 - [x] Write tests for setting a bit in a byte.
 - [x] Write tests for clearing a bit in a byte.
 - [x] Write unit tests for reading the super block.

--- a/TODO_DONE.md
+++ b/TODO_DONE.md
@@ -1,0 +1,10 @@
+
+- [x] Write tests for setting a bit in a byte.
+- [x] Write tests for clearing a bit in a byte.
+- [x] Write unit tests for reading the super block.
+- [x] Write a test build in the Makefile.
+- [x] Work on imap.
+    - [x] decoding hex to binary with the correct bit order.
+    - [x] building a bit map for inodes.
+- [x] Write a note on design choice for data types (i8, u8, i32, u32,...) for efficient byte array decoding/encoding
+- [x] Write a note on design choice using both `i8 *` and `std::string`

--- a/app-c/.gitignore
+++ b/app-c/.gitignore
@@ -1,7 +1,7 @@
 **/build/
 **target/
 **.out
-**/test_disk
+**/vdisk
 
 # Created by https://www.toptal.com/developers/gitignore/api/bazel
 # Edit at https://www.toptal.com/developers/gitignore?templates=bazel

--- a/app-c/Makefile
+++ b/app-c/Makefile
@@ -27,7 +27,8 @@ src_test_units  := src/test-units
 build_units     := ${target_test}/units
 build_runner    := ${target_test}
 
-test_units_o    := fs.ext2.o fs.ext2.imap.o fs.ext2.imap.bits.o fs.ext2.inode_table.o
+test_units_o    := fs.ext2.o fs.ext2.imap.o fs.ext2.imap.bits.o fs.ext2.inode_table.o \
+									 fs.ext2.root_dir_entries.o
 
 test_units_o    := ${addprefix ${build_units}/, ${test_units_o}}
 

--- a/app-c/Makefile
+++ b/app-c/Makefile
@@ -27,7 +27,7 @@ src_test_units  := src/test-units
 build_units     := ${target_test}/units
 build_runner    := ${target_test}
 
-test_units_o    := fs.ext2.o fs.ext2.imap.o fs.ext2.imap.bits.o
+test_units_o    := fs.ext2.o fs.ext2.imap.o fs.ext2.imap.bits.o fs.ext2.inode_table.o
 
 test_units_o    := ${addprefix ${build_units}/, ${test_units_o}}
 

--- a/app-c/Makefile
+++ b/app-c/Makefile
@@ -17,7 +17,7 @@ build_lib_o     := utils.o
 
 build_lib_o     := ${addprefix ${build_lib}/, ${build_lib_o}}
 
-app 						:= ${target_main}/app
+app             := ${target_main}/app
 
 # build unit tests and runner
 ##################################################################

--- a/app-c/automaton/disk
+++ b/app-c/automaton/disk
@@ -1,0 +1,21 @@
+#!/usr/bin/env nu
+
+$env.temp_diskname = "vdisk";
+def "main mount" [--name (-n): string] {
+  if ($name | str length) > 0 {
+    sudo losetup /dev/loop20 $"($name)";
+    sudo mount /dev/loop20 /mnt;
+    echo $"($name) is mounted!"
+    $env.temp_diskname = name;
+  } else {
+    echo "no disk name!";
+  }
+}
+
+def "main umount" [] {
+  sudo umount /mnt;
+  sudo losetup -d /dev/loop20;
+  echo $"($env.temp_diskname) is umounted!"; 
+}
+
+def main [] {}

--- a/app-c/automaton/make-vdisk
+++ b/app-c/automaton/make-vdisk
@@ -1,7 +1,7 @@
 # bs: converts and write UP TO bs BYTES at a time.
 WRITE_LIMIT=1024
 # Copies from `if` (input file) to `of` (output file). Each action has an upper limit of `bs`. Repeats for `count` blocks.
-dd if=/dev/zero of=test_disk bs=$WRITE_LIMIT count=1440
+dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440
 # Converts the file with name `-l` into an EXT2/3/4 disk. Writes upt to `-b` number of blocks.
-mke2fs -c test_disk -b 1440
+mke2fs -c vdisk -b 1440
 

--- a/app-c/automaton/mount-disk
+++ b/app-c/automaton/mount-disk
@@ -1,0 +1,2 @@
+sudo losetup /dev/loop20 vdisk;
+sudo mount /dev/loop20 /mnt;

--- a/app-c/automaton/mount-disk
+++ b/app-c/automaton/mount-disk
@@ -1,2 +1,0 @@
-sudo losetup /dev/loop20 vdisk;
-sudo mount /dev/loop20 /mnt;

--- a/app-c/automaton/run
+++ b/app-c/automaton/run
@@ -1,6 +1,6 @@
 # make clean
 make app
-DISK=test_disk
+DISK=vdisk
 APP=build/main/app
 chmod +x $APP
 ./$APP $DISK

--- a/app-c/automaton/umount-disk
+++ b/app-c/automaton/umount-disk
@@ -1,0 +1,2 @@
+sudo umount /mnt;
+sudo losetup -d /dev/loop20;

--- a/app-c/automaton/umount-disk
+++ b/app-c/automaton/umount-disk
@@ -1,2 +1,0 @@
-sudo umount /mnt;
-sudo losetup -d /dev/loop20;

--- a/app-c/src/hdr-locked/constants.hpp
+++ b/app-c/src/hdr-locked/constants.hpp
@@ -5,7 +5,19 @@
 
 namespace constants {
     constexpr u32 BASE_BLOCK_SIZE = 1024;
-    constexpr u16 MAGIC_NUMBER    = 0xef53;
+    constexpr u32 MAGIC_NUMBER    = 0xef53;
+    constexpr u32 SUPER_BLOCK     = 1;
+    constexpr u32 GD_BLOCK        = 2;
+    constexpr u32 ROOT_INODE      = 2;
+
+    constexpr u32 DIR_MODE  = 0x41ed;
+    constexpr u32 FILE_MODE = 0x81ae;
+
+    /*
+     * contains other constants and enum.
+     */
+    // constexpr u32 SUPER_USER = 0;
+
 }  // namespace constants
 
 #endif

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -69,20 +69,23 @@ namespace FS {
                 if (!ext2->super_block && ext2->group_desc_block) {
                     return;
                 }
-                GD *gdp            = (GD *)(ext2->group_desc_block);
-                i32 imap_block_num = gdp->bg_inode_bitmap;
+                GD       *gdp       = (GD *)(ext2->group_desc_block);
+                const u32 block_num = gdp->bg_inode_bitmap;
 
-                read_block(ext2->fd, imap_block_num, ext2->imap);
+                read_block(ext2->fd, block_num, ext2->imap);
             }
 
             /**
              * reads disk information from the SUPER block.
              */
             static SUPER *super(FS::EXT2 *ext2) {
-                i32 fd = ext2->fd, blksize = ext2->blksize;
-                i8 *super_block = ext2->super_block;
-                lseek(fd, blksize * 1, SEEK_SET);
-                read(fd, super_block, blksize);
+                const u32 fd          = ext2->fd;
+                const u32 block_num   = 1;
+                i8       *super_block = ext2->super_block;
+
+                // lseek(fd, blksize * block_num, SEEK_SET);
+                // read(fd, super_block, blksize);
+                read_block(fd, block_num, super_block);
                 SUPER *sp = (SUPER *)super_block;
 
                 //  as a super_block block structure, check EXT2 FS magic number:
@@ -99,11 +102,15 @@ namespace FS {
             /**
              * reads group information from the GD block.
              */
-            static void group_desc(FS::EXT2 *ext2) {
-                i32 fd = ext2->fd, blksize = ext2->blksize;
-                GD *group_desc_block = (GD *)ext2->group_desc_block;
-                lseek(fd, blksize * 2, SEEK_SET);
-                read(fd, group_desc_block, blksize);
+            static GD *group_desc(FS::EXT2 *ext2) {
+                const u32 fd               = ext2->fd;  //, blksize = ext2->blksize;
+                const u32 block_num        = 2;
+                i8       *group_desc_block = ext2->group_desc_block;
+                // lseek(fd, blksize * block_num, SEEK_SET);
+                // read(fd, group_desc_block, blksize);
+                read_block(fd, block_num, group_desc_block);
+                GD *gdp = (GD *)group_desc_block;
+                return gdp;
             }
         };
     }  // namespace Read

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -154,6 +154,10 @@ namespace FS {
 
                 DIR_ENTRY *dep = (DIR_ENTRY *)buf;
 
+                /*
+                 * BUG: currently doesn't show the correct inode number and dir entries.
+                 * TODO: write test for this.
+                 */
                 // while (rp < buf + constants::BASE_BLOCK_SIZE) {
                 std::strncpy(record_name, dep->name, dep->name_len);
                 record_name[dep->name_len] = 0;

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -155,19 +155,21 @@ namespace FS {
                  *  - get data block buffer.
                  *  - jump forward by the record's length of each dir_entry.
                  */
-                i8 record_name[256];
+                //i8 record_name[256];
 
 
                 i8 *rp = ext2->root_node;  // record pointer
 
                 DIR_ENTRY *dep = (DIR_ENTRY *)ext2->root_node;
 
+                // NOTE: the inode number is very large, might even be outside the bound of vdisk.
+                // TODO: check this value later.
                 // BUG: there is still a problem with the while loop.
                 //while (rp < buf + constants::BASE_BLOCK_SIZE) {
-                    std::strncpy(record_name, dep->name, dep->name_len);
-                    record_name[dep->name_len] = 0;
-                    // std::string record_name = std::string(dep->name, dep->rec_len);
-                    printf("inode[%d] %d %d %s\t", dep->inode, dep->rec_len, dep->name_len, record_name);
+                    //std::strncpy(record_name, dep->name, dep->name_len);
+                    //record_name[dep->name_len] = 0;
+                     std::string record_name = std::string(dep->name, dep->rec_len);
+                    printf("inode[%d] %d %d %s\t", dep->inode, dep->rec_len, dep->name_len, record_name.c_str());
                     rp += dep->rec_len;
                     dep = (DIR_ENTRY *)rp;
                 //}

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -147,8 +147,10 @@ namespace FS {
                  */
                 i8 buf[constants::BASE_BLOCK_SIZE], record_name[256];
 
-                auto iTABLE = 20;
-                FS::Read::EXT2::read_block(ext2->fd, iTABLE, buf);
+                /*
+                 * BUG: is here
+                 */
+                FS::Read::EXT2::read_block(ext2->fd, ext2->first_inode_num, buf);
 
                 i8 *rp = buf;  // record pointer
 
@@ -171,16 +173,20 @@ namespace FS {
             static void inode_table(FS::EXT2 const *const ext2) {
                 INODE *ip = (INODE *)ext2->inode_table;
                 ++ip;
-                printf("\nmode = %4x ", ip->i_mode);
-                printf("\nuid = %d gid = %d", ip->i_uid, ip->i_gid);
-                printf("\nsize = %d", ip->i_size);
+                printf("\nmode  = %x", ip->i_mode);
+                printf("\nuid   = %d", ip->i_uid);
+                printf("\ngid   = %d", ip->i_gid);
+                printf("\nsize  = %d", ip->i_size);
                 printf("\nctime = %s", std::ctime((i64 *)&ip->i_ctime));
-                printf("\nlinks = %d\n", ip->i_links_count);
+                printf("links = %d\n", ip->i_links_count);
                 for (u32 i = 0; i < 15; i++) {
+                    if (i % 3 == 0) {
+                        printf("\n");
+                    }
                     // print disk block numbers
-                    if (ip->i_block[i])
-                        // print non-zero blocks only
-                        printf("i_block[%d] = %d\n", i, ip->i_block[i]);
+                    // if (ip->i_block[i])
+                    // print non-zero blocks only
+                    printf("\ti_block[%2d] = %d \t", i, ip->i_block[i]);
                 }
                 printf("\n");
             }

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -134,12 +134,12 @@ namespace FS {
     namespace Show {
         struct EXT2 {
             static void inode_table(FS::EXT2 const *const ext2) {
-                GD       *gdp       = (GD *)(ext2->group_desc_block);
-                //const u32 block_num = gdp->bg_inode_table;
-                const u32 block_num = 10;
+                //GD *gdp = (GD *)(ext2->group_desc_block);
+                 //const u32 block_num = gdp->bg_inode_table;
+                //const u32 block_num = 10;
 
-                i8 buf[constants::BASE_BLOCK_SIZE];
-                FS::Read::EXT2::read_block(ext2->fd, 10, buf);
+                //i8 buf[constants::BASE_BLOCK_SIZE];
+                //FS::Read::EXT2::read_block(ext2->fd, 10, buf);
 
                 INODE *ip = (INODE *)ext2->inode_table;
                 ++ip;
@@ -192,7 +192,7 @@ namespace FS {
                     if (i % 4 == 0) {
                         printf("\n");
                     }
-                    printf("\tbytes[%02d]  %02x  ", i + 1, (u8)imap[i]);
+                    printf("\tbytes[%3d]  %02x  ", i + 1, (u8)imap[i]);
                     u8 *bitstring = byte2bitstring((u8)imap[i]);
                     print_bitstring(bitstring);
                     delete bitstring;

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -57,7 +57,7 @@ namespace FS {
     namespace Read {
         struct EXT2 {
             /**
-             * read the block in to a buffer
+             * read the block in to an i8 buffer
              */
             static size_t read_block(i32 fd, u32 block_num, i8 *buffer) {
                 lseek(fd, block_num * constants::BASE_BLOCK_SIZE, SEEK_SET);
@@ -257,7 +257,7 @@ namespace FS {
         };
     }  // namespace Show
 
-    namespace Update {
+    namespace Write {
         struct EXT2 {
             static u8 set_bit(u8 byte, u8 index) {
                 return byte | (u8)(1 << index);
@@ -267,6 +267,6 @@ namespace FS {
                 return byte ^ (u8)(1 << index);
             }
         };
-    }  // namespace Update
+    }  // namespace Write
 };     // namespace FS
 #endif

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -162,9 +162,11 @@ namespace FS {
 
                 DIR_ENTRY *dep = (DIR_ENTRY *)ext2->root_node;
 
-                // NOTE: the inode number is very large, might even be outside the bound of vdisk.
-                // TODO: check this value later.
-                // BUG: there is still a problem with the while loop.
+                /*
+                 * NOTE: the inode number is very large, might even be outside the bound of vdisk.
+                 * TODO: check this value later against the upper bound of the total inodes (disksize = 4MB).
+                 * BUG: there is still a problem with the while loop.
+                */
                 //while (rp < buf + constants::BASE_BLOCK_SIZE) {
                     //std::strncpy(record_name, dep->name, dep->name_len);
                     //record_name[dep->name_len] = 0;

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -10,8 +10,6 @@
 #include <string>
 #include <unistd.h>
 
-#include <assert.h>
-
 #include <ext2fs/ext2_fs.h>
 
 #include "constants.hpp"
@@ -166,11 +164,12 @@ namespace FS {
              * NOTE:
              *  - Memory is allocated in chunks. This is done automatically as an optimization by the computer.
              *      - https://www.c-faq.com/struct/align.html
-             *  - `Each byte` is represented as `2 hex values`, effectively compressing the amount of data shown from 16 points to 2 points.
+             *  - `Each byte` is represented as `2 hex values`, effectively compressing the amount of data from 8 points to 2 points.
+             *      - e.g. `0xff <- 0x11111111`
              *      - This encoding scheme is an example of `symbolic abstraction`.
              *      - We use a symbolic value (hex) to represent a larger amount of information (bits).
              *          - We have to read less but still extract the same amount of meaning from the heap of information.
-             *          - When we need to, we can decode the hex values and expand them into a `bitmap` of 2 bit strings.
+             *          - When we need to, we can decode the hex values and expand them into a `bitmap` or bitstring.
              */
             static void imap(FS::EXT2 const *const ext2, const i8 *const) {
                 SUPER *sp         = (SUPER *)(ext2->super_block);

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -115,9 +115,20 @@ namespace FS {
         };
     }  // namespace Read
 
+    namespace Update {
+        struct EXT2 {
+            static u8 set_bit(u8 byte, u8 index) {
+                return byte | (u8)(1 << index);
+            }
+
+            static u8 clear_bit(u8 byte, u8 index) {
+                return byte ^ (u8)(1 << index);
+            }
+        };
+    }  // namespace Update
+
     namespace Show {
         struct EXT2 {
-
             /**
              * build a bitmap from the byte passed in.
              */
@@ -127,14 +138,6 @@ namespace FS {
                     bitstring[i] = (value & static_cast<u8>(1 << (i % 8))) >> (i % 8);
                 }
                 return bitstring;
-            }
-
-            static u8 set_bit(u8 byte, u8 index) {
-                return byte | (u8)(1 << index);
-            }
-
-            static u8 clear_bit(u8 byte, u8 index) {
-                return byte ^ (u8)(1 << index);
             }
 
             /**

--- a/app-c/src/hdr-locked/my-fs.hpp
+++ b/app-c/src/hdr-locked/my-fs.hpp
@@ -66,13 +66,16 @@ namespace FS {
     namespace Read {
         struct EXT2 {
             /**
-             * read the block in to an i8 buffer
+             * read the block in to an i8 buffer.
              */
             static size_t read_block(i32 fd, u32 block_num, i8 *buffer) {
                 lseek(fd, block_num * constants::BASE_BLOCK_SIZE, SEEK_SET);
                 return read(fd, buffer, constants::BASE_BLOCK_SIZE);
             }
 
+            /**
+             * read the entries of the root node.
+             */
             static void root_node(FS::EXT2 *ext2) {
                 INODE *ip = (INODE *)(ext2->inode_table);
                 ++ip;
@@ -144,26 +147,14 @@ namespace FS {
     namespace Show {
         struct EXT2 {
             static void root_node(FS::EXT2 const *const ext2) {
-                /*
-                 * TODO: implement the algorithm to step through the dir entries (`dir_entries`) in an inode's data block.
-                 *  - get data block buffer.
-                 *  - jump forward by the record's length of each dir_entry.
-                 */
-                // i8 record_name[256];
-
-                i8 *rp = ext2->root_node;  // record pointer
-
-                DIR_ENTRY *dep = (DIR_ENTRY *)ext2->root_node;
-
+                i8        *rp = ext2->root_node;  // record pointer
+                DIR_ENTRY *dp = (DIR_ENTRY *)ext2->root_node;
+                printf("%8s %8s %8s %10s\n", "inode#", "rec_len", "name_len", "rec_name");
                 while (rp < ext2->root_node + constants::BASE_BLOCK_SIZE) {
-                    std::string record_name = std::string(dep->name, dep->rec_len);
-                    // printf("inode[%d] %d %d %s\t", dep->inode, dep->rec_len, dep->name_len, record_name.c_str());
-                    printf("\ninode_num    = %d", dep->inode);
-                    printf("\nrec_len      = %d", dep->rec_len);
-                    printf("\nrec_name_len = %d", dep->name_len);
-                    printf("\nrec_name     = %s\n", record_name.c_str());
-                    rp += dep->rec_len;
-                    dep = (DIR_ENTRY *)rp;
+                    std::string record_name = std::string(dp->name, dp->rec_len);
+                    printf("%8d %8d %8d %10s\n", dp->inode, dp->rec_len, dp->name_len, record_name.c_str());
+                    rp += dp->rec_len;
+                    dp = (DIR_ENTRY *)rp;
                 }
             }
 
@@ -181,9 +172,9 @@ namespace FS {
                         printf("\n");
                     }
                     // print disk block numbers
-                    if (ip->i_block[i])
-                        // print non-zero blocks only
-                        printf("\ti_block[%2d] = %d \t", i, ip->i_block[i]);
+                    if (ip->i_block[i]) {
+                        printf("\ti_block[%2d] = %d \t", i, ip->i_block[i]);  // print non-zero blocks only
+                    }
                 }
                 printf("\n");
             }

--- a/app-c/src/test-units/all-tests.hpp
+++ b/app-c/src/test-units/all-tests.hpp
@@ -24,5 +24,6 @@ struct Test {
 void test_fs_ext2();
 void test_fs_ext2_imap();
 void test_fs_ext2_imap_bits();
+void test_fs_ext2_inode_table();
 
 #endif

--- a/app-c/src/test-units/all-tests.hpp
+++ b/app-c/src/test-units/all-tests.hpp
@@ -25,5 +25,6 @@ void test_fs_ext2();
 void test_fs_ext2_imap();
 void test_fs_ext2_imap_bits();
 void test_fs_ext2_inode_table();
+void test_fs_ext2_root_dir_entries();
 
 #endif

--- a/app-c/src/test-units/fs.ext2.cc
+++ b/app-c/src/test-units/fs.ext2.cc
@@ -27,7 +27,6 @@ bool _test_fs_ext2() {
         system(create_vdisk.c_str());
     }();
 
-
     /**
      * TEST BODY
      */
@@ -35,7 +34,7 @@ bool _test_fs_ext2() {
         i8 const *const diskname = "vdisk";
         FS::EXT2        vdisk(diskname);
         FS::SUPER      *sp = FS::Read::EXT2::super(&vdisk);
-
+        FS::Show::EXT2::super(&vdisk);
         assert(sp->s_magic == constants::MAGIC_NUMBER);
         assert(sp->s_log_block_size == 0);  // 0 for ext2
     }

--- a/app-c/src/test-units/fs.ext2.cc
+++ b/app-c/src/test-units/fs.ext2.cc
@@ -17,14 +17,14 @@ bool _test_fs_ext2() {
      * SET UP
      */
     []() -> void {
-        string create_test_disk{
-            "if [ ! -f test_disk ]; then "
+        string create_vdisk{
+            "if [ ! -f vdisk ]; then "
             "WRITE_LIMIT=1024;"
-            "dd if=/dev/zero of=test_disk bs=$WRITE_LIMIT count=1440;"
-            "mke2fs -c test_disk -b 1440;"
+            "dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440;"
+            "mke2fs -c vdisk -b 1440;"
             "fi"};
 
-        system(create_test_disk.c_str());
+        system(create_vdisk.c_str());
     }();
 
 
@@ -32,7 +32,7 @@ bool _test_fs_ext2() {
      * TEST BODY
      */
     {
-        i8 const *const diskname = "test_disk";
+        i8 const *const diskname = "vdisk";
         FS::EXT2        vdisk(diskname);
         FS::SUPER      *sp = FS::Read::EXT2::super(&vdisk);
 
@@ -45,13 +45,13 @@ bool _test_fs_ext2() {
      */
     [=]()
         -> void {
-        // string remove_test_disk{
+        // string remove_vdisk{
         //"echo cleaning up the test...;"
-        //"if [ -f test_disk ]; then "
-        //"rm test_disk;"
+        //"if [ -f vdisk ]; then "
+        //"rm vdisk;"
         //"fi"
         //};
-        // system(remove_test_disk.c_str());
+        // system(remove_vdisk.c_str());
     }();
     return true;
 }

--- a/app-c/src/test-units/fs.ext2.imap.bits.cc
+++ b/app-c/src/test-units/fs.ext2.imap.bits.cc
@@ -31,7 +31,7 @@ bool _test_fs_ext2_imap_bits() {
         u8 bit_index = 5;
         u8 expect    = 112;
 
-        u32 result = FS::Show::EXT2::set_bit(value, bit_index);
+        u32 result = FS::Update::EXT2::set_bit(value, bit_index);
         assert(result == expect);
 
         /**
@@ -46,7 +46,7 @@ bool _test_fs_ext2_imap_bits() {
         bit_index = 5;
         expect    = 80;
 
-        result = FS::Show::EXT2::clear_bit(value, bit_index);
+        result = FS::Update::EXT2::clear_bit(value, bit_index);
         assert(result == expect);
     }
 

--- a/app-c/src/test-units/fs.ext2.imap.bits.cc
+++ b/app-c/src/test-units/fs.ext2.imap.bits.cc
@@ -31,7 +31,7 @@ bool _test_fs_ext2_imap_bits() {
         u8 bit_index = 5;
         u8 expect    = 112;
 
-        u32 result = FS::Update::EXT2::set_bit(value, bit_index);
+        u32 result = FS::Write::EXT2::set_bit(value, bit_index);
         assert(result == expect);
 
         /**
@@ -46,7 +46,7 @@ bool _test_fs_ext2_imap_bits() {
         bit_index = 5;
         expect    = 80;
 
-        result = FS::Update::EXT2::clear_bit(value, bit_index);
+        result = FS::Write::EXT2::clear_bit(value, bit_index);
         assert(result == expect);
     }
 

--- a/app-c/src/test-units/fs.ext2.imap.cc
+++ b/app-c/src/test-units/fs.ext2.imap.cc
@@ -35,6 +35,7 @@ bool _test_fs_ext2_imap() {
 
         FS::Read::EXT2::super(&vdisk);
         FS::Read::EXT2::group_desc(&vdisk);
+        FS::Show::EXT2::group_desc(&vdisk);
         FS::Read::EXT2::imap(&vdisk);
         // show bitmap of inodes.
         FS::Show::EXT2::imap(&vdisk);

--- a/app-c/src/test-units/fs.ext2.imap.cc
+++ b/app-c/src/test-units/fs.ext2.imap.cc
@@ -16,21 +16,21 @@ bool _test_fs_ext2_imap() {
      * SET UP
      */
     []() -> void {
-        string create_test_disk{
-            "if [ ! -f test_disk ]; then "
+        string create_vdisk{
+            "if [ ! -f vdisk ]; then "
             "WRITE_LIMIT=1024;"
-            "dd if=/dev/zero of=test_disk bs=$WRITE_LIMIT count=1440;"
-            "mke2fs -c test_disk -b 1440;"
+            "dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440;"
+            "mke2fs -c vdisk -b 1440;"
             "fi"};
 
-        system(create_test_disk.c_str());
+        system(create_vdisk.c_str());
     }();
 
     /**
      * TEST BODY
      */
     {
-        i8 const *const diskname = "test_disk";
+        i8 const *const diskname = "vdisk";
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
@@ -45,13 +45,13 @@ bool _test_fs_ext2_imap() {
      */
     [=]()
         -> void {
-        // string remove_test_disk{
+        // string remove_vdisk{
         //"echo cleaning up the test...;"
-        //"if [ -f test_disk ]; then "
-        //"rm test_disk;"
+        //"if [ -f vdisk ]; then "
+        //"rm vdisk;"
         //"fi"
         //};
-        // system(remove_test_disk.c_str());
+        // system(remove_vdisk.c_str());
     }();
     return true;
 }

--- a/app-c/src/test-units/fs.ext2.inode_table.cc
+++ b/app-c/src/test-units/fs.ext2.inode_table.cc
@@ -34,7 +34,9 @@ bool _test_fs_ext2_inode_table() {
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
+        FS::Show::EXT2::super(&vdisk);
         FS::Read::EXT2::group_desc(&vdisk);
+        FS::Show::EXT2::group_desc(&vdisk);
         FS::Read::EXT2::inode_table(&vdisk);
         FS::Show::EXT2::inode_table(&vdisk);
     }

--- a/app-c/src/test-units/fs.ext2.inode_table.cc
+++ b/app-c/src/test-units/fs.ext2.inode_table.cc
@@ -16,14 +16,14 @@ bool _test_fs_ext2_inode_table() {
      * SET UP
      */
     []() -> void {
-        string create_vdisk{
-            "if [ ! -f vdisk ]; then "
-            "WRITE_LIMIT=1024;"
-            "dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440;"
-            "mke2fs -c vdisk -b 1440;"
-            "fi"};
+        //string create_vdisk{
+            //"if [ ! -f vdisk ]; then "
+            //"WRITE_LIMIT=1024;"
+            //"dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440;"
+            //"mke2fs -c vdisk -b 1440;"
+            //"fi"};
 
-        system(create_vdisk.c_str());
+        //system(create_vdisk.c_str());
     }();
 
     /**
@@ -34,10 +34,7 @@ bool _test_fs_ext2_inode_table() {
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
-
         FS::Read::EXT2::group_desc(&vdisk);
-        FS::Show::EXT2::group_desc(&vdisk);
-
         FS::Read::EXT2::imap(&vdisk);
 
         FS::Read::EXT2::inode_table(&vdisk);

--- a/app-c/src/test-units/fs.ext2.inode_table.cc
+++ b/app-c/src/test-units/fs.ext2.inode_table.cc
@@ -1,0 +1,65 @@
+#include "../hdr-locked/constants.hpp"
+#include "../hdr-locked/my-fs.hpp"
+#include "../hdr-locked/my-types.hpp"
+
+#include "all-tests.hpp"
+
+#include <cassert>
+
+using std::string;
+
+/**
+ * Integration test. create a new disk and read from it.
+ */
+bool _test_fs_ext2_inode_table() {
+    /**
+     * SET UP
+     */
+    []() -> void {
+        string create_test_disk{
+            "if [ ! -f test_disk ]; then "
+            "WRITE_LIMIT=1024;"
+            "dd if=/dev/zero of=test_disk bs=$WRITE_LIMIT count=1440;"
+            "mke2fs -c test_disk -b 1440;"
+            "fi"};
+
+        system(create_test_disk.c_str());
+    }();
+
+    /**
+     * TEST BODY
+     */
+    {
+        i8 const *const diskname = "test_disk";
+        FS::EXT2        vdisk(diskname);
+
+        FS::Read::EXT2::super(&vdisk);
+        FS::Read::EXT2::group_desc(&vdisk);
+        FS::Read::EXT2::inode_table(&vdisk);
+        FS::Show::EXT2::inode_table(&vdisk);
+    }
+
+    /**
+     * TEAR DOWN
+     */
+    [=]()
+        -> void {
+        // string remove_test_disk{
+        //"echo cleaning up the test...;"
+        //"if [ -f test_disk ]; then "
+        //"rm test_disk;"
+        //"fi"
+        //};
+        // system(remove_test_disk.c_str());
+    }();
+    return true;
+}
+
+/**
+ * test executor.
+ */
+void test_fs_ext2_inode_table() {
+    Test::Header("show inode table");
+    bool result = Test::Body(*_test_fs_ext2_inode_table);
+    Test::Footer(result);
+}

--- a/app-c/src/test-units/fs.ext2.inode_table.cc
+++ b/app-c/src/test-units/fs.ext2.inode_table.cc
@@ -34,11 +34,15 @@ bool _test_fs_ext2_inode_table() {
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
-        FS::Show::EXT2::super(&vdisk);
+
         FS::Read::EXT2::group_desc(&vdisk);
-        FS::Show::EXT2::group_desc(&vdisk);
+
+        FS::Read::EXT2::imap(&vdisk);
+
         FS::Read::EXT2::inode_table(&vdisk);
         FS::Show::EXT2::inode_table(&vdisk);
+
+        FS::Show::EXT2::dir_entry(&vdisk);
     }
 
     /**

--- a/app-c/src/test-units/fs.ext2.inode_table.cc
+++ b/app-c/src/test-units/fs.ext2.inode_table.cc
@@ -16,21 +16,21 @@ bool _test_fs_ext2_inode_table() {
      * SET UP
      */
     []() -> void {
-        string create_test_disk{
-            "if [ ! -f test_disk ]; then "
+        string create_vdisk{
+            "if [ ! -f vdisk ]; then "
             "WRITE_LIMIT=1024;"
-            "dd if=/dev/zero of=test_disk bs=$WRITE_LIMIT count=1440;"
-            "mke2fs -c test_disk -b 1440;"
+            "dd if=/dev/zero of=vdisk bs=$WRITE_LIMIT count=1440;"
+            "mke2fs -c vdisk -b 1440;"
             "fi"};
 
-        system(create_test_disk.c_str());
+        system(create_vdisk.c_str());
     }();
 
     /**
      * TEST BODY
      */
     {
-        i8 const *const diskname = "test_disk";
+        i8 const *const diskname = "vdisk";
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
@@ -46,13 +46,13 @@ bool _test_fs_ext2_inode_table() {
      */
     [=]()
         -> void {
-        // string remove_test_disk{
+        // string remove_vdisk{
         //"echo cleaning up the test...;"
-        //"if [ -f test_disk ]; then "
-        //"rm test_disk;"
+        //"if [ -f vdisk ]; then "
+        //"rm vdisk;"
         //"fi"
         //};
-        // system(remove_test_disk.c_str());
+        // system(remove_vdisk.c_str());
     }();
     return true;
 }

--- a/app-c/src/test-units/fs.ext2.root_dir_entries.cc
+++ b/app-c/src/test-units/fs.ext2.root_dir_entries.cc
@@ -11,7 +11,7 @@ using std::string;
 /**
  * Integration test. create a new disk and read from it.
  */
-bool _test_fs_ext2_inode_table() {
+bool _test_fs_ext2_root_dir_entries() {
     /**
      * SET UP
      */
@@ -36,12 +36,13 @@ bool _test_fs_ext2_inode_table() {
         FS::Read::EXT2::super(&vdisk);
 
         FS::Read::EXT2::group_desc(&vdisk);
-        FS::Show::EXT2::group_desc(&vdisk);
 
         FS::Read::EXT2::imap(&vdisk);
 
         FS::Read::EXT2::inode_table(&vdisk);
         FS::Show::EXT2::inode_table(&vdisk);
+
+        FS::Show::EXT2::dir_entry(&vdisk);
     }
 
     /**
@@ -63,8 +64,8 @@ bool _test_fs_ext2_inode_table() {
 /**
  * test executor.
  */
-void test_fs_ext2_inode_table() {
-    Test::Header("show inode table");
-    bool result = Test::Body(*_test_fs_ext2_inode_table);
+void test_fs_ext2_root_dir_entries() {
+    Test::Header("show root node dir entries");
+    bool result = Test::Body(*_test_fs_ext2_root_dir_entries);
     Test::Footer(result);
 }

--- a/app-c/src/test-units/fs.ext2.root_dir_entries.cc
+++ b/app-c/src/test-units/fs.ext2.root_dir_entries.cc
@@ -34,15 +34,11 @@ bool _test_fs_ext2_root_dir_entries() {
         FS::EXT2        vdisk(diskname);
 
         FS::Read::EXT2::super(&vdisk);
-
         FS::Read::EXT2::group_desc(&vdisk);
-
         FS::Read::EXT2::imap(&vdisk);
-
         FS::Read::EXT2::inode_table(&vdisk);
-        FS::Show::EXT2::inode_table(&vdisk);
-
-        FS::Show::EXT2::dir_entry(&vdisk);
+        FS::Read::EXT2::root_node(&vdisk);
+        FS::Show::EXT2::root_node(&vdisk);
     }
 
     /**

--- a/app-c/src/test/runner.cc
+++ b/app-c/src/test/runner.cc
@@ -9,6 +9,7 @@ int main() {
     //test_fs_ext2();
     test_fs_ext2_imap();
     test_fs_ext2_imap_bits();
+    test_fs_ext2_inode_table();
 
     printf("\n\nALL: PASSED.\n");
 }

--- a/app-c/src/test/runner.cc
+++ b/app-c/src/test/runner.cc
@@ -6,7 +6,7 @@
 
 int main() {
     printf("\n\nRUNNING TESTS.\n\n");
-    //test_fs_ext2();
+    test_fs_ext2();
     test_fs_ext2_imap();
     test_fs_ext2_imap_bits();
     test_fs_ext2_inode_table();

--- a/app-c/src/test/runner.cc
+++ b/app-c/src/test/runner.cc
@@ -10,6 +10,7 @@ int main() {
     test_fs_ext2_imap();
     test_fs_ext2_imap_bits();
     test_fs_ext2_inode_table();
+    test_fs_ext2_root_dir_entries();
 
     printf("\n\nALL: PASSED.\n");
 }

--- a/model/system-test/strategy.md
+++ b/model/system-test/strategy.md
@@ -1,4 +1,16 @@
 
+## Important Notes
+
+### On the Vdisk Sample
+
+I adapted the source code in some unit tests to send bash scripts to the shell. I did this to accomplish 2 goals:
+	- to see whether that communication between the program and the shell environment is possible
+	- to automate creating new ext2 filesystems for deterministic test results.
+
+However, at the current stage of development (early stage 1, building functionality) the empty ext2 has a problem: there are no records on every new vdisk. This is why I am going to appropriate the sample of vdisk from KC's. This sample has some existing inode records (both dir and file). This simplifies testing.
+
+## General Strategy
+
 This document lays out the strategy for building up unit tests for the project. Testing should be deeply integrated into the development process. 
 
 In general, a particular product needs to be tested on three aspects: functionality, integrity and viability. These three aspects map to unit tests, integration tests and E2E tests, in that order. For this shell program, unit tests will be a very common recurrence. Eventually, once we have gotten to the software packaging phase, we will consider how to conduct integration test.


### PR DESCRIPTION
- Moved set and clear bit functions to a new namespace `FS::Write::EXT2`
- Added script to mount & umount vdisk.
- Collapsed the disk mount and unmount scripts into sub commands in a single nu script.
- Trying to fix the bug where i_block[i] doesn't show anything at all.
- Fixed the pointer arithmetic error when reading root node to buffer. It should be incremented by 1 after being cast to `(INODE *)` because inode numbers are 1-based.
- Reformatted the output of dir entries when Show'ed.
- Added BUG and FIX notes for reading and showing the root `INODE`.